### PR TITLE
Fixed importing functions did not work because of previous commit

### DIFF
--- a/enkelt.py
+++ b/enkelt.py
@@ -394,9 +394,13 @@ def parse(lexed, token_index):
 		else:
 			transpile_keyword(token_val)
 	elif token_type == 'USER_FUNCTION':
+		# Needed when functions are imported functions
+		token_val = token_val.replace('.', '__IMPORTED__')
 		source_code.append('def ' + token_val + '(')
 		needs_start_statuses.append(True)
 	elif token_type == 'USER_FUNCTION_CALL':
+		# Needed when functions are imported functions
+		token_val = token_val.replace('.', '__IMPORTED__')
 		source_code.append(token_val + '(')
 	elif token_type == 'CLASS':
 		source_code.append(' ' + token_val)


### PR DESCRIPTION
I removed the line that replaced . with _ because I thought it was unnecessary turns out it's needed for importing functions. It now replaces . with __IMPORTED__ because it's less likely to be used.